### PR TITLE
Packaging / installation improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,18 +16,4 @@ include_directories(
     )
 
 add_subdirectory(pybind11)
-
-pybind11_add_module(optix src/main.cpp)
-target_link_libraries( optix PRIVATE
-	"${CUDA_LIBRARIES}"
-	)
-target_compile_features( optix PRIVATE 
-    cxx_std_17
-    )
-
-add_custom_command(
-    TARGET optix POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-    ${OptiX_INCLUDE}
-    $<TARGET_FILE_DIR:optix>/include
-)
+add_subdirectory(optix)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,3 +25,9 @@ target_compile_features( optix PRIVATE
     cxx_std_17
     )
 
+add_custom_command(
+    TARGET optix POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_directory
+    ${OptiX_INCLUDE}
+    $<TARGET_FILE_DIR:optix>/include
+)

--- a/README.md
+++ b/README.md
@@ -39,29 +39,11 @@ pip3 install --global-option build --global-option --debug .
 
 ## Running the example
 
-The example can be run from the root of the repository with:
+The example can be run from the examples directory with:
 
 ```
-python examples/hello.py
-```
-
-It may be necessary to modify the include path used by nvrtc to find the OptiX
-headers at their actualy installed location. For example:
-
-```diff
-diff --git a/examples/hello.py b/examples/hello.py
-index 16a153e..317cc37 100755
---- a/examples/hello.py
-+++ b/examples/hello.py
-@@ -73,7 +73,7 @@ def compile_cuda( cuda_file ):
-         #'-IC:\\ProgramData\\NVIDIA Corporation\OptiX SDK 7.2.0\include',
-         #'-IC:\\Program Files\\NVIDIA GPU Computing Toolkit\CUDA\\v11.1\include'
-         '-I/usr/local/cuda/include',
--        '-I/home/kmorley/Code/support/NVIDIA-OptiX-SDK-7.2.0-linux64-x86_64/include/'
-+        '-I/home/gmarkall/numbadev/NVIDIA-OptiX-SDK-7.2.0-linux64-x86_64/include/'
-         ] )
-     return ptx
- 
+cd examples
+python hello.py
 ```
 
 If the example runs successfully, a green square will be rendered.

--- a/examples/hello.py
+++ b/examples/hello.py
@@ -2,6 +2,7 @@
 
 
 import optix
+import os
 import cupy  as cp    # CUDA bindings
 import numpy as np    # Packing of structures in C-compatible format
 
@@ -70,10 +71,9 @@ def compile_cuda( cuda_file ):
         '-std=c++11',
         '-rdc',
         'true',
-        #'-IC:\\ProgramData\\NVIDIA Corporation\OptiX SDK 7.2.0\include',
         #'-IC:\\Program Files\\NVIDIA GPU Computing Toolkit\CUDA\\v11.1\include'
         '-I/usr/local/cuda/include',
-        '-I/home/kmorley/Code/support/NVIDIA-OptiX-SDK-7.2.0-linux64-x86_64/include/'
+        f'-I{optix.include_path}'
         ] )
     return ptx
 
@@ -320,7 +320,8 @@ def launch( pipeline, sbt ):
 
 
 def main():
-    hello_ptx = compile_cuda( "examples/hello.cu" )
+    hello_cu = os.path.join(os.path.dirname(__file__), 'hello.cu')
+    hello_ptx = compile_cuda(hello_cu)
 
     init_optix()
 

--- a/optix/CMakeLists.txt
+++ b/optix/CMakeLists.txt
@@ -1,0 +1,11 @@
+pybind11_add_module(_optix ${CMAKE_SOURCE_DIR}/src/main.cpp)
+
+target_link_libraries(_optix PRIVATE "${CUDA_LIBRARIES}")
+target_compile_features(_optix PRIVATE cxx_std_17)
+
+add_custom_command(
+  TARGET _optix POST_BUILD
+  COMMAND ${CMAKE_COMMAND} -E copy_directory
+  ${OptiX_INCLUDE}
+  $<TARGET_FILE_DIR:_optix>/include
+)

--- a/optix/__init__.py
+++ b/optix/__init__.py
@@ -1,0 +1,2 @@
+from ._optix import *
+from .nvrtc_support import include_path

--- a/optix/nvrtc_support.py
+++ b/optix/nvrtc_support.py
@@ -1,0 +1,3 @@
+import os
+
+include_path = os.path.join(os.path.dirname(__file__), 'include')

--- a/setup.py
+++ b/setup.py
@@ -69,9 +69,9 @@ class CMakeBuild(build_ext):
 setup(
     name='optix',
     version='0.0.1',
-    author='Dean Moldovan',
-    author_email='dean0x7d@gmail.com',
-    description='A test project using pybind11 and CMake',
+    author='Keith Morley',
+    author_email='kmorley@nvidia.com',
+    description='Python bindings for NVIDIA OptiX',
     long_description='',
     ext_modules=[CMakeExtension('optix')],
     cmdclass=dict(build_ext=CMakeBuild),

--- a/setup.py
+++ b/setup.py
@@ -73,8 +73,9 @@ setup(
     author_email='kmorley@nvidia.com',
     description='Python bindings for NVIDIA OptiX',
     long_description='',
-    ext_modules=[CMakeExtension('optix')],
+    ext_modules=[CMakeExtension('optix._optix')],
     cmdclass=dict(build_ext=CMakeBuild),
+    packages=['optix'],
     install_requires=['pynvrtc'],
     zip_safe=False,
 )

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1332,13 +1332,13 @@ void computeStackSizesSimplePathTracer(
 } // end namespace pyoptix
 
 
-PYBIND11_MODULE( optix, m ) 
+PYBIND11_MODULE( _optix, m ) 
 {
     m.doc() = R"pbdoc(
         OptiX API 
         -----------------------
 
-        .. currentmodule:: optix
+        .. currentmodule:: _optix
 
         .. autosummary::
            :toctree: _generate


### PR DESCRIPTION
This PR makes several packaging-related changes:

- A new package, `optix`, is created, and the existing `optix` Python extension is moved to `optix._optix`. The result is that the optix files are now all installed in the `site-packages/optix` subdirectory, instead of peppering the `site-packages` folder itself with optix files.
- The `optix` package imports everything from `optix._optix`, preserving the interface that provides all functions under the `optix` package. This provides the opportunity for Python code to implement some of the optix package, whilst still enabling use of the Python extension.
- OptiX headers are also installed into the `optix` package, and a function for locating the include path is provided (`optix.include_path`).
- Correspondingly, the example is updated so that it no longer needs a hardcoded include path (also the path to hello.cu is determined based on the location of hello.py, rather than being hardcoded).