### PR TITLE
Use optix include path for triangle

### DIFF
--- a/examples/triangle.py
+++ b/examples/triangle.py
@@ -73,7 +73,7 @@ def compile_cuda( cuda_file ):
         #'-IC:\\ProgramData\\NVIDIA Corporation\OptiX SDK 7.2.0\include',
         #'-IC:\\Program Files\\NVIDIA GPU Computing Toolkit\CUDA\\v11.1\include'
         '-I/usr/local/cuda/include',
-        '-I/home/kmorley/Code/support/NVIDIA-OptiX-SDK-7.3.0-linux64-x86_64/include/'
+        f'-I{optix.include_path}'
         ] )
     return ptx
 


### PR DESCRIPTION
This removes the requirement for manually editing the example, by using the OptiX includes installed into the environment by setup.py.