### PR TITLE
Changes for building on Windows:

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,11 @@ pip3 install --global-option build --global-option --debug .
 `<optix install dir>` should be the OptiX 7.3.0 install location - for example,
 `/home/user/NVIDIA-OptiX-SDK-7.3.0-linux64-x86_64`.
 
+For windows the environment variable can be set like this:
+```
+set PYOPTIX_CMAKE_ARGS=-DOptix_INSTALL_DIR=C:\ProgramData\NVIDIA Corporation\OptiX SDK 7.0.0
+```
+
 When compiling against an Optix 7.0 SDK build also set a path variable pointing
 to the system's stddef.h location. E.g.
 ```

--- a/examples/hello.py
+++ b/examples/hello.py
@@ -10,6 +10,8 @@ import array
 import ctypes         # C interop helpers
 from PIL import Image # Image IO
 
+from pynvrtc.compiler import Program
+
 
 #-------------------------------------------------------------------------------
 #
@@ -62,8 +64,12 @@ def array_to_device_memory( numpy_array, stream=cp.cuda.Stream() ):
 def compile_cuda( cuda_file ):
     with open( cuda_file, 'rb' ) as f:
         src = f.read()
-    from pynvrtc.compiler import Program
-    prog = Program( src.decode(), cuda_file )
+    nvrtc_dll = os.environ.get('NVRTC_DLL')
+    if nvrtc_dll is None:
+        nvrtc_dll = ''
+    print("NVRTC_DLL = {}".format(nvrtc_dll))
+    prog = Program( src.decode(), cuda_file,
+                    lib_name= nvrtc_dll )
     compile_options = [
         '-use_fast_math', 
         '-lineinfo',

--- a/examples/triangle.py
+++ b/examples/triangle.py
@@ -2,12 +2,15 @@
 
 
 import optix
+import os
 import cupy  as cp    # CUDA bindings
 import numpy as np    # Packing of structures in C-compatible format
 
 import array
 import ctypes         # C interop helpers
 from PIL import Image, ImageOps # Image IO
+
+from pynvrtc.compiler import Program
 
 
 #-------------------------------------------------------------------------------
@@ -61,8 +64,12 @@ def array_to_device_memory( numpy_array, stream=cp.cuda.Stream() ):
 def compile_cuda( cuda_file ):
     with open( cuda_file, 'rb' ) as f:
         src = f.read()
-    from pynvrtc.compiler import Program
-    prog = Program( src.decode(), cuda_file )
+    nvrtc_dll = os.environ.get('NVRTC_DLL')
+    if nvrtc_dll is None:
+        nvrtc_dll = ''
+    print("NVRTC_DLL = {}".format(nvrtc_dll))
+    prog = Program( src.decode(), cuda_file,
+                    lib_name= nvrtc_dll )
     compile_options = [
         '-use_fast_math', 
         '-lineinfo',
@@ -70,6 +77,7 @@ def compile_cuda( cuda_file ):
         '-std=c++11',
         '-rdc',
         'true',
+        #'-IC:\\Program Files\\NVIDIA GPU Computing Toolkit\CUDA\\v11.1\include'
         f'-I{optix.cuda_tk_path}',
         f'-I{optix.include_path}'
     ]

--- a/optix/nvrtc_support.py
+++ b/optix/nvrtc_support.py
@@ -1,8 +1,0 @@
-import os
-
-print("__file__ = {}".format(__file__))
-include_path = os.path.join(os.path.dirname(__file__), 'include')
-
-cuda_tk_path = "/usr/local/cuda/include"
-stddef_path = "/usr/include/linux"
-

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,6 +4,7 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
+#define NOMINMAX 
 #include <optix.h>
 #include <optix_stubs.h>
 #include <optix_function_table_definition.h>
@@ -402,7 +403,7 @@ struct ModuleCompileOptions
 };
 #endif
 
-#if OPTIX_VERSION < 70000
+#if OPTIX_VERSION > 70000
 struct BuiltinISOptions
 {
     OptixBuiltinISOptions options;


### PR DESCRIPTION
* Add #define NOMINMAX to main.cpp to make VisualStudio C++ conform to standard.
* Add NVRTC_DLL environment varialbe with path to that DLL. The sample programs
(hello.py and triangle.py) check if that variable is set and use its value to
initialize the nvrtc wrapper accordingly.
The main issue this solves is that on Windows, the nvrtc dlls have version as part of name, and thus a wrapper compiled for a different version of CUDATK will not find the dll with its symbols.