### PR TITLE
Making optix module independent of nvrtc.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ include_directories(
     "${CUDA_INCLUDE_DIRS}"
     )
 
-configure_file("${CMAKE_SOURCE_DIR}/nvrtc_support.py.in" "${CMAKE_SOURCE_DIR}/optix/nvrtc_support.py")
+configure_file("${CMAKE_SOURCE_DIR}/path_util.py.in" "${CMAKE_SOURCE_DIR}/examples/path_util.py")
 
 add_subdirectory(pybind11)
 add_subdirectory(optix)

--- a/examples/hello.py
+++ b/examples/hello.py
@@ -10,6 +10,7 @@ import array
 import ctypes         # C interop helpers
 from PIL import Image # Image IO
 
+import path_util
 
 #-------------------------------------------------------------------------------
 #
@@ -72,9 +73,11 @@ def compile_cuda( cuda_file ):
         '-rdc',
         'true',
         #'-IC:\\Program Files\\NVIDIA GPU Computing Toolkit\CUDA\\v11.1\include'
-        f'-I{optix.cuda_tk_path}',
-        f'-I{optix.include_path}'
+        f'-I{path_util.cuda_tk_path}',
+        f'-I{path_util.include_path}'
     ]
+
+    print("include_path = {}".format(path_util.include_path))
     # Optix 7.0 compiles need path to system stddef.h
     # the value of optix.stddef_path is compiled in constant. When building
     # the module, the value can be specified via an environment variable, e.g.

--- a/nvrtc_support.py.in
+++ b/nvrtc_support.py.in
@@ -1,8 +1,0 @@
-import os
-
-print("__file__ = {}".format(__file__))
-include_path = os.path.join(os.path.dirname(__file__), 'include')
-
-cuda_tk_path = "${CUDA_TOOLKIT_INCLUDE}"
-stddef_path = "${OptiX_STDDEF_DIR}"
-

--- a/optix/__init__.py
+++ b/optix/__init__.py
@@ -1,2 +1,2 @@
 from ._optix import *
-from .nvrtc_support import include_path, cuda_tk_path, stddef_path
+

--- a/optix/nvrtc_support.py
+++ b/optix/nvrtc_support.py
@@ -1,8 +1,0 @@
-import os
-
-print("__file__ = {}".format(__file__))
-include_path = os.path.join(os.path.dirname(__file__), 'include')
-
-cuda_tk_path = "/usr/local/cuda/include"
-stddef_path = ""
-

--- a/path_util.py.in
+++ b/path_util.py.in
@@ -1,0 +1,7 @@
+import os
+
+print("__file__ = {}".format(__file__))
+include_path = "${OptiX_INCLUDE}"
+cuda_tk_path = "${CUDA_INCLUDE_DIRS}"
+stddef_path = "${OptiX_STDDEF_DIR}"
+


### PR DESCRIPTION
Compile paths for nvrtc are now generated by CMake in path_utils.py which is put directly into
the example directory. At the moment only examples need to compile using nvrtc.